### PR TITLE
ABIEncoder v2 is enabled by default in solidity ^0.8.0

### DIFF
--- a/contracts/Wallet.sol
+++ b/contracts/Wallet.sol
@@ -1,8 +1,5 @@
 pragma solidity ^0.8.6;
 
-// TODO are there any risks in using this experimental ABIEncoderV2? Reference: Aave uses it also
-pragma experimental ABIEncoderV2;
-
 import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IWallet.sol";

--- a/contracts/bridges/AaveV2DepositBridge/AaveV2DepositBridge.sol
+++ b/contracts/bridges/AaveV2DepositBridge/AaveV2DepositBridge.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.8.6;
-pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -2,8 +2,6 @@ pragma solidity ^0.8.6;
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "../libraries/IPDataTypes.sol";
 
-pragma experimental ABIEncoderV2; // TODO is this necessary?
-
 interface IIndexPool is IERC721 { // TODO should we add interface for ownable?
     function createPortfolio(
         IPDataTypes.TokenData calldata inputs,

--- a/contracts/interfaces/IWallet.sol
+++ b/contracts/interfaces/IWallet.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.8.6;
 
-pragma experimental ABIEncoderV2; // TODO is this necessary?
-
 interface IWallet {
     function write(address[] calldata _bridgeAddresses, bytes[] calldata _bridgeEncodedCalls) external;
 


### PR DESCRIPTION
ABIEncoder v2 is enabled by default in solidity ^0.8.0. Ref.: https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html#:~:text=ABI%20coder%20v2,abicoder%20v2%3B%20instead.